### PR TITLE
Fixing Window NamedTemporaryFile issue

### DIFF
--- a/kafka_helper.py
+++ b/kafka_helper.py
@@ -40,9 +40,9 @@ def get_kafka_ssl_context():
     # SSLContext inside the with so when it goes out of scope the files are removed which has them
     # existing for the shortest amount of time.  As extra caution password
     # protect/encrypt the client key
-    with NamedTemporaryFile(suffix='.crt') as cert_file, \
-         NamedTemporaryFile(suffix='.key') as key_file, \
-         NamedTemporaryFile(suffix='.crt') as trust_file:
+    with NamedTemporaryFile(suffix='.crt', delete = False) as cert_file, \
+         NamedTemporaryFile(suffix='.key', delete = False) as key_file, \
+         NamedTemporaryFile(suffix='.crt', delete = False) as trust_file:
         cert_file.write(os.environ['KAFKA_CLIENT_CERT'].encode('utf-8'))
         cert_file.flush()
 


### PR DESCRIPTION
Without the 'delete = False' flag in NamedTemporaryFile, the ssl socket established by this package is invalid on Windows